### PR TITLE
Refactor 1.0.1

### DIFF
--- a/src/Service/Contract/UserRolePermissionsServiceInterface.php
+++ b/src/Service/Contract/UserRolePermissionsServiceInterface.php
@@ -25,12 +25,12 @@ interface UserRolePermissionsServiceInterface extends ServiceInterface
     /**
      * Update a user role permission. Matching on the $match parameter.
      *
-     * @param \Symfony\Component\HttpFoundation\ParameterBag $payload
-     * @param string                                         $match
+     * @param \ArchLayerUser\Entity\Contract\UserRolePermissionsEntityInterface|\Illuminate\Database\Eloquent\Model $entity
+     * @param \Symfony\Component\HttpFoundation\ParameterBag                                                        $payload
      *
      * @return bool
      */
-    public function update(ParameterBag $payload, $match = 'id'): bool;
+    public function update(UserRolePermissionsEntityInterface $entity, ParameterBag $payload): bool;
 
     /**
      * Delete a user role permission.

--- a/src/Service/Contract/UserRoleServiceInterface.php
+++ b/src/Service/Contract/UserRoleServiceInterface.php
@@ -25,12 +25,12 @@ interface UserRoleServiceInterface extends ServiceInterface
     /**
      * Update a user role entity. Match parameter is used to select column to match on.
      *
-     * @param \Symfony\Component\HttpFoundation\ParameterBag $payload
-     * @param string                                         $match
+     * @param \ArchLayerUser\Entity\Contract\UserRoleEntityInterface|\Illuminate\Database\Eloquent\Model $entity
+     * @param \Symfony\Component\HttpFoundation\ParameterBag                                             $payload
      *
      * @return bool
      */
-    public function update(ParameterBag $payload, $match = 'id'): bool;
+    public function update(UserRoleEntityInterface $entity, ParameterBag $payload): bool;
 
     /**
      * Delete a user role entity.

--- a/src/Service/Contract/UserServiceInterface.php
+++ b/src/Service/Contract/UserServiceInterface.php
@@ -25,12 +25,12 @@ interface UserServiceInterface extends ServiceInterface
     /**
      * Update a user's attributes in the database. Match parameter is used to select column to match on.
      *
-     * @param \Symfony\Component\HttpFoundation\ParameterBag $payload
-     * @param string                                         $match
+     * @param \ArchLayerUser\Entity\Contract\UserEntityInterface|\Illuminate\Database\Eloquent\Model $entity
+     * @param \Symfony\Component\HttpFoundation\ParameterBag                                         $payload
      *
      * @return bool
      */
-    public function update(ParameterBag $payload, $match = 'id'): bool;
+    public function update(UserEntityInterface $entity, ParameterBag $payload): bool;
 
     /**
      * Delete a user from the database.

--- a/src/Service/UserRolePermissionsService.php
+++ b/src/Service/UserRolePermissionsService.php
@@ -47,14 +47,14 @@ class UserRolePermissionsService extends Service implements UserRolePermissionsS
     /**
      * Update a user role permission. Matching on the $match parameter.
      *
-     * @param \Symfony\Component\HttpFoundation\ParameterBag $payload
-     * @param string                                         $match
+     * @param \ArchLayerUser\Entity\Contract\UserRolePermissionsEntityInterface|\Illuminate\Database\Eloquent\Model $entity
+     * @param \Symfony\Component\HttpFoundation\ParameterBag                                                        $payload
      *
      * @return bool
      */
-    public function update(ParameterBag $payload, $match = 'id'): bool
+    public function update(UserRolePermissionsEntityInterface $entity, ParameterBag $payload): bool
     {
-        return $this->getRepository()->builder()->where($match, $payload->get($match))->update(
+        return $entity->update(
             Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable())
         );
     }

--- a/src/Service/UserRolePermissionsService.php
+++ b/src/Service/UserRolePermissionsService.php
@@ -35,10 +35,10 @@ class UserRolePermissionsService extends Service implements UserRolePermissionsS
      */
     public function create(ParameterBag $payload): UserRolePermissionsEntityInterface
     {
-        $attributes = Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable());
-
         /** @var \ArchLayerUser\Entity\UserRolePermissionEntity $user */
-        $permission = $this->getRepository()->create($attributes);
+        $permission = $this->getRepository()->create(
+            Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable())
+        );
         $permission->save();
 
         return $permission;

--- a/src/Service/UserRoleService.php
+++ b/src/Service/UserRoleService.php
@@ -35,10 +35,10 @@ class UserRoleService extends Service implements UserRoleServiceInterface
      */
     public function create(ParameterBag $payload): UserRoleEntityInterface
     {
-        $attributes = Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable());
-
         /** @var \ArchLayerUser\Entity\UserRoleEntity $user */
-        $user = $this->getRepository()->create($attributes);
+        $user = $this->getRepository()->create(
+            Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable())
+        );
         $user->save();
 
         return $user;

--- a/src/Service/UserRoleService.php
+++ b/src/Service/UserRoleService.php
@@ -47,14 +47,14 @@ class UserRoleService extends Service implements UserRoleServiceInterface
     /**
      * Update a user role entity. Match parameter is used to select column to match on.
      *
-     * @param \Symfony\Component\HttpFoundation\ParameterBag $payload
-     * @param string                                         $match
+     * @param \ArchLayerUser\Entity\Contract\UserRoleEntityInterface|\Illuminate\Database\Eloquent\Model $entity
+     * @param \Symfony\Component\HttpFoundation\ParameterBag                                             $payload
      *
      * @return bool
      */
-    public function update(ParameterBag $payload, $match = 'id'): bool
+    public function update(UserRoleEntityInterface $entity, ParameterBag $payload): bool
     {
-        return $this->getRepository()->builder()->where($match, $payload->get($match))->update(
+        return $entity->update(
             Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable())
         );
     }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -47,14 +47,14 @@ class UserService extends Service implements UserServiceInterface
     /**
      * Update a user's attributes in the database. Match parameter is used to select column to match on.
      *
-     * @param \Symfony\Component\HttpFoundation\ParameterBag $payload
-     * @param string                                         $match
+     * @param \ArchLayerUser\Entity\Contract\UserEntityInterface|\Illuminate\Database\Eloquent\Model $entity
+     * @param \Symfony\Component\HttpFoundation\ParameterBag                                         $payload
      *
      * @return bool
      */
-    public function update(ParameterBag $payload, $match = 'id'): bool
+    public function update(UserEntityInterface $entity, ParameterBag $payload): bool
     {
-        return $this->getRepository()->builder()->where($match, $payload->get($match))->update(
+        return $entity->update(
             Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable())
         );
     }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -35,10 +35,10 @@ class UserService extends Service implements UserServiceInterface
      */
     public function create(ParameterBag $payload): UserEntityInterface
     {
-        $attributes = Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable());
-
         /** @var \ArchLayerUser\Entity\UserEntity $user */
-        $user = $this->getRepository()->create($attributes);
+        $user = $this->getRepository()->create(
+            Arr::only($payload->all(), $this->getRepository()->getModel()->getFillable())
+        );
         $user->save();
 
         return $user;


### PR DESCRIPTION
Change log:
- Signatures for ```update()``` on ```User```, ```UserRole``` and ```UserRolePermission``` services accept the original entity and new attributes as ```ParameterBag``` rather than new attributes and key to match on.
- Refactored ```create()``` on ```User```, ```UserRole``` and ```UserRolePermission``` services - removed ```$attributes``` variable as only used once in method.